### PR TITLE
Fix build contexts in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,16 @@ version: '3.9'
 
 services:
   backend:
-    build: https://github.com/AntGod6123/Mnemo.git#main:backend
+    build:
+      context: ./backend
     ports:
       - "8000:8000"
     volumes:
       - ./data:/app/data
 
   frontend:
-    build: https://github.com/AntGod6123/Mnemo.git#main:frontend
+    build:
+      context: ./frontend
     ports:
       - "3000:3000"
 


### PR DESCRIPTION
## Summary
- update `docker-compose.yml` to build `backend` and `frontend` from local folders

## Testing
- `docker` command not found, so no compose config validation could be run

------
https://chatgpt.com/codex/tasks/task_e_684570c53fe8833288aa2fee9bbfa5ee