### PR TITLE
Make LLM optional and configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built for educators, researchers, archivists, and knowledge enthusiasts who want
 ## ✨ Features
 
 - 🔍 **Unified Search** across multiple ZIM files (with fuzzy matching)
-- 🤖 **Local LLM Assistant** (via Ollama, llama.cpp, etc.)
+- 🤖 **Optional LLM Assistant** (connect your own service)
 - 📑 **Tabbed Article Viewer** with rich media handling
 - 🗣️ **Translation Plugin** powered by Argos Translate
 - 💡 **LAN Sharing** for offline local networks
@@ -24,7 +24,7 @@ Built for educators, researchers, archivists, and knowledge enthusiasts who want
 - **Backend**: Python FastAPI with modular services (ZIM loader, search, LLM, translation)
 - **Frontend**: React + Vite + TailwindCSS for a fast, responsive UI
 - **Storage**: SQLite (bookmarks, user profiles, config)
-- **Deployment**: Docker Compose with support for NGINX + Ollama
+- **Deployment**: Docker Compose for backend and frontend
 
 ---
 
@@ -37,13 +37,20 @@ docker-compose up --build
 
 ``` 
 
-This command builds the backend, frontend, and LLM containers and then starts
-them. Once the build completes, visit <http://localhost:3000> to use the
-interface. The FastAPI backend is available at <http://localhost:8000> and the
-LLM service runs on <http://localhost:11434>. When you're done, stop the stack
-with <kbd>Ctrl</kbd>+<kbd>C</kbd> and clean up the containers using:
+This command builds the backend and frontend containers. After they start,
+visit <http://localhost:3000> to use the interface. The FastAPI backend is
+available at <http://localhost:8000>. If you want LLM features, run your own
+service separately (for example an Ollama container) and configure its URL in
+the admin panel. When you're done, stop the stack with <kbd>Ctrl</kbd>+<kbd>C</kbd>
+and clean up the containers using:
 
 ```bash
 docker-compose down
 
 ```
+
+### Enabling LLM Features
+
+Open the admin panel and supply the URL and API key of your own LLM service.
+Unchecking the option hides these fields and disables AI responses in the
+search interface.

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -10,10 +10,18 @@ router = APIRouter()
 
 class ConfigModel(BaseModel):
     zim_dir: str
+    llm_enabled: bool = False
+    llm_url: str = "http://localhost:11434/api/generate"
+    llm_api_key: str | None = None
 
 def load_config():
     if not os.path.exists(CONFIG_PATH):
-        return {"zim_dir": "/data/zim"}
+        return {
+            "zim_dir": "/data/zim",
+            "llm_enabled": False,
+            "llm_url": "http://localhost:11434/api/generate",
+            "llm_api_key": ""
+        }
     with open(CONFIG_PATH) as f:
         return json.load(f)
 

--- a/backend/routes/llm.py
+++ b/backend/routes/llm.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 import requests
 from routes.zim_loader import get_article
+from routes.config import load_config
 
 router = APIRouter()
 
-LLM_URL = "http://localhost:11434/api/generate"  # Ollama
 
 class LLMQuery(BaseModel):
     query: str
@@ -14,6 +14,11 @@ class LLMQuery(BaseModel):
 
 @router.post("/llm/query")
 def llm_query(data: LLMQuery):
+    config = load_config()
+    if not config.get("llm_enabled"):
+        return {"answer": ""}
+    llm_url = config.get("llm_url", "http://localhost:11434/api/generate")
+    api_key = config.get("llm_api_key")
     context = ""
 
     if data.zim_id and data.context_path:
@@ -27,8 +32,12 @@ def llm_query(data: LLMQuery):
         "stream": False
     }
 
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
     try:
-        res = requests.post(LLM_URL, json=payload)
+        res = requests.post(llm_url, json=payload, headers=headers)
         result = res.json()
         return {
             "answer": result.get("response", "").strip(),

--- a/data/config.json
+++ b/data/config.json
@@ -1,1 +1,6 @@
-{ "zim_dir": "/data/zim" }
+{
+  "zim_dir": "/data/zim",
+  "llm_enabled": false,
+  "llm_url": "http://localhost:11434/api/generate",
+  "llm_api_key": ""
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,4 @@ services:
     ports:
       - "3000:3000"
 
-  llm:
-    image: ollama/ollama
-    ports:
-      - "11434:11434"
-    volumes:
-      - ollama-data:/root/.ollama
-
-volumes:
-  ollama-data:
+  # Provision your own LLM service and update the config via the admin UI

--- a/frontend/components/LLMChatPanel.jsx
+++ b/frontend/components/LLMChatPanel.jsx
@@ -1,11 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 export default function LLMChatPanel() {
   const [chat, setChat] = useState([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [llmEnabled, setLlmEnabled] = useState(false);
+
+  useEffect(() => {
+    fetch('/admin/config')
+      .then(res => res.json())
+      .then(cfg => setLlmEnabled(cfg.llm_enabled));
+  }, []);
 
   const sendMessage = async () => {
+    if (!llmEnabled) return;
     setLoading(true);
     const res = await fetch('/llm/query', {
       method: 'POST',
@@ -17,6 +25,8 @@ export default function LLMChatPanel() {
     setInput('');
     setLoading(false);
   };
+
+  if (!llmEnabled) return null;
 
   return (
     <div className="p-4">

--- a/frontend/components/PluginManager.jsx
+++ b/frontend/components/PluginManager.jsx
@@ -2,12 +2,20 @@ import React, { useEffect, useState } from 'react';
 
 export default function PluginManager() {
   const [zimDir, setZimDir] = useState('');
+  const [llmEnabled, setLlmEnabled] = useState(false);
+  const [llmUrl, setLlmUrl] = useState('');
+  const [llmKey, setLlmKey] = useState('');
   const [message, setMessage] = useState('');
 
   useEffect(() => {
     fetch('/admin/config')
       .then(res => res.json())
-      .then(data => setZimDir(data.zim_dir || ''));
+      .then(data => {
+        setZimDir(data.zim_dir || '');
+        setLlmEnabled(data.llm_enabled || false);
+        setLlmUrl(data.llm_url || '');
+        setLlmKey(data.llm_api_key || '');
+      });
   }, []);
 
   const saveConfig = async () => {
@@ -15,7 +23,12 @@ export default function PluginManager() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ zim_dir: zimDir })
+      body: JSON.stringify({
+        zim_dir: zimDir,
+        llm_enabled: llmEnabled,
+        llm_url: llmUrl,
+        llm_api_key: llmKey
+      })
     });
     const result = await res.json();
     setMessage(result.message || 'Saved');
@@ -32,6 +45,32 @@ export default function PluginManager() {
           onChange={e => setZimDir(e.target.value)}
         />
       </div>
+      <div className="mb-4">
+        <label className="inline-flex items-center gap-2">
+          <input type="checkbox" checked={llmEnabled} onChange={e => setLlmEnabled(e.target.checked)} />
+          Enable LLM
+        </label>
+      </div>
+      {llmEnabled && (
+        <div className="mb-4 space-y-4">
+          <div>
+            <label className="block mb-1">LLM URL</label>
+            <input
+              className="w-full p-2 border rounded dark:bg-gray-800 dark:text-white"
+              value={llmUrl}
+              onChange={e => setLlmUrl(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block mb-1">API Key</label>
+            <input
+              className="w-full p-2 border rounded dark:bg-gray-800 dark:text-white"
+              value={llmKey}
+              onChange={e => setLlmKey(e.target.value)}
+            />
+          </div>
+        </div>
+      )}
       <button
         onClick={saveConfig}
         className="px-4 py-2 bg-blue-600 text-white rounded"


### PR DESCRIPTION
## Summary
- allow admin to enable/disable LLM integration
- make LLM URL and key configurable through admin panel
- update backend routes to respect configuration
- remove bundled Ollama container from compose file
- adjust frontend search and chat panels to hide when LLM disabled
- document how to connect your own LLM service

## Testing
- `python -m py_compile backend/**/*.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457d8468e483328800e100115b9408