### PR TITLE
Add admin logging functionality

### DIFF
--- a/backend/logger.py
+++ b/backend/logger.py
@@ -1,0 +1,16 @@
+import logging
+import os
+
+LOG_FILE = "./data/server.log"
+os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger("mnemo")

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,9 @@ from routes.zim_routes import router as zim_router
 from routes.translate import router as translate_router
 from routes.llm import router as llm_router
 from routes.auth import router as auth_router
+from routes.logs import router as logs_router
 from routes.zim_loader import load_zim_files
+from logger import logger
 
 app = FastAPI()
 
@@ -26,6 +28,8 @@ app.include_router(zim_router)
 app.include_router(translate_router)
 app.include_router(llm_router)
 app.include_router(auth_router)
+app.include_router(logs_router)
 
 # Load ZIMs on startup
+logger.info("Mnemo server starting up")
 load_zim_files()

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 import json
 import os
 import bcrypt
+from logger import logger
 
 router = APIRouter()
 
@@ -24,12 +25,15 @@ def login(data: LoginRequest, response: Response):
         if user["username"] == data.username:
             if bcrypt.checkpw(data.password.encode(), user["password"].encode()):
                 response.set_cookie("zim_admin", user["username"], httponly=True)
+                logger.info(f"User {data.username} logged in")
                 return {"message": "Login successful", "username": user["username"]}
+    logger.warning(f"Failed login attempt for {data.username}")
     raise HTTPException(status_code=401, detail="Invalid credentials")
 
 @router.post("/auth/logout")
 def logout(response: Response):
     response.delete_cookie("zim_admin")
+    logger.info("User logged out")
     return {"message": "Logged out"}
 
 @router.get("/auth/status")

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -5,6 +5,7 @@ import json
 import os
 from routes.zim_loader import load_zim_files
 import argostranslate.package as argos_pkg
+from logger import logger
 
 CONFIG_PATH = "./data/config.json"
 router = APIRouter()
@@ -44,6 +45,7 @@ def update_config(config: ConfigModel, request: Request):
     if session != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
     save_config(config.dict())
+    logger.info("Configuration updated")
     load_zim_files()  # dynamically reload ZIMs
     return {"message": "Config updated and ZIMs reloaded", "config": config}
 
@@ -58,6 +60,8 @@ def update_argos(request: Request):
         for p in pkgs:
             path = argos_pkg.download_package(p)
             argos_pkg.install_from_path(path)
+        logger.info("Argos packages updated")
         return {"message": "Argos packages updated"}
     except Exception as e:
+        logger.error(f"Argos update failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/routes/logs.py
+++ b/backend/routes/logs.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, Request, HTTPException
+import os
+
+LOG_FILE = "./data/server.log"
+
+router = APIRouter()
+
+@router.get("/admin/logs")
+def read_logs(request: Request):
+    session = request.cookies.get("zim_admin")
+    if session != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+    if not os.path.exists(LOG_FILE):
+        return {"logs": ""}
+    with open(LOG_FILE) as f:
+        lines = f.readlines()
+    return {"logs": "".join(lines[-200:])}

--- a/backend/routes/zim_loader.py
+++ b/backend/routes/zim_loader.py
@@ -5,6 +5,7 @@ import sqlite3
 from pyzim.reader import ZIMReader
 from pathlib import Path
 from threading import Lock
+from logger import logger
 
 ZIM_INDEX = {}
 ZIM_META = []
@@ -55,7 +56,7 @@ def load_zim_files():
         overrides = config.get("zim_overrides", {})
 
         if not zim_dir.exists():
-            print("ZIM directory not found")
+            logger.error("ZIM directory not found")
             return
 
         meta_cache = []
@@ -83,9 +84,9 @@ def load_zim_files():
                 meta_cache.append(zim_meta)
                 ZIM_META.append(zim_meta)
 
-                print(f"Loaded {zim_path.name} with {len(articles)} articles")
+                logger.info(f"Loaded {zim_path.name} with {len(articles)} articles")
             except Exception as e:
-                print(f"Failed to load {zim_path.name}: {e}")
+                logger.error(f"Failed to load {zim_path.name}: {e}")
 
         save_cache(meta_cache)
 

--- a/frontend/components/PluginManager.jsx
+++ b/frontend/components/PluginManager.jsx
@@ -8,6 +8,7 @@ export default function PluginManager() {
   const [llmKey, setLlmKey] = useState('');
   const [message, setMessage] = useState('');
   const [overridesText, setOverridesText] = useState('');
+  const [logs, setLogs] = useState('');
 
   useEffect(() => {
     apiFetch('/admin/config')
@@ -45,6 +46,12 @@ export default function PluginManager() {
     });
     const data = await res.json();
     setMessage(data.message || 'Update complete');
+  };
+
+  const loadLogs = async () => {
+    const res = await apiFetch('/admin/logs', { credentials: 'include' });
+    const data = await res.json();
+    setLogs(data.logs || '');
   };
 
   return (
@@ -104,6 +111,17 @@ export default function PluginManager() {
       >
         Update Argos Models
       </button>
+      <button
+        onClick={loadLogs}
+        className="ml-2 px-4 py-2 bg-gray-600 text-white rounded"
+      >
+        Refresh Logs
+      </button>
+      {logs && (
+        <pre className="mt-4 p-2 bg-gray-100 dark:bg-gray-900 text-xs overflow-auto h-60 whitespace-pre-wrap">
+          {logs}
+        </pre>
+      )}
       {message && <div className="mt-2 text-green-600">{message}</div>}
     </div>
   );


### PR DESCRIPTION
## Summary
- configure a logger for the backend
- expose `/admin/logs` endpoint
- log various server events
- allow admins to view logs from the plugin manager

## Testing
- `python -m py_compile backend/main.py backend/logger.py backend/routes/config.py backend/routes/zim_loader.py backend/routes/auth.py backend/routes/logs.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6e3673483328edf5328d23efeb1