### PR TITLE
Handle database errors in search route

### DIFF
--- a/backend/routes/search.py
+++ b/backend/routes/search.py
@@ -9,21 +9,29 @@ def search_articles(q: str = Query(..., min_length=1)):
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()
 
-    cur.execute("""
+    try:
+        cur.execute(
+            """
         SELECT zim_id, title, path
         FROM articles
         WHERE articles MATCH ?
         LIMIT 50
-    """, (q,))
-    rows = cur.fetchall()
-    conn.close()
+        """,
+            (q,),
+        )
+        rows = cur.fetchall()
+    except sqlite3.OperationalError:
+        rows = []
+    finally:
+        conn.close()
 
     return {
         "results": [
             {
                 "zim_id": row["zim_id"],
                 "title": row["title"],
-                "path": row["path"]
-            } for row in rows
+                "path": row["path"],
+            }
+            for row in rows
         ]
     }


### PR DESCRIPTION
## Summary
- catch `sqlite3.OperationalError` when running the search query
- always close the database connection
- return empty results on failure

## Testing
- `python -m py_compile backend/routes/search.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b2b4ed848332b0ba023890caea61