### PR TITLE
Handle database errors in search

### DIFF
--- a/backend/routes/search.py
+++ b/backend/routes/search.py
@@ -1,29 +1,28 @@
 from fastapi import APIRouter, Query
 import sqlite3
+from logger import logger
 
 router = APIRouter()
 
 @router.get("/search")
 def search_articles(q: str = Query(..., min_length=1)):
-    conn = sqlite3.connect("./cache/search_index.db")
-    conn.row_factory = sqlite3.Row
-    cur = conn.cursor()
-
     try:
-        cur.execute(
-            """
-        SELECT zim_id, title, path
-        FROM articles
-        WHERE articles MATCH ?
-        LIMIT 50
-        """,
-            (q,),
-        )
-        rows = cur.fetchall()
-    except sqlite3.OperationalError:
-        rows = []
-    finally:
-        conn.close()
+        with sqlite3.connect("./cache/search_index.db") as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.cursor()
+            cur.execute(
+                """
+            SELECT zim_id, title, path
+            FROM articles
+            WHERE articles MATCH ?
+            LIMIT 50
+            """,
+                (q,),
+            )
+            rows = cur.fetchall()
+    except sqlite3.OperationalError as e:
+        logger.warning(f"Search query failed: {e}")
+        return {"results": []}
 
     return {
         "results": [


### PR DESCRIPTION
## Summary
- add logger import to search API
- use a context manager for SQLite connections
- return an empty result set and log a warning if the query fails

## Testing
- `python -m py_compile backend/routes/search.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b4611564833289e172fdf8840393