### PR TITLE
Add error handling for overrides JSON

### DIFF
--- a/frontend/components/PluginManager.jsx
+++ b/frontend/components/PluginManager.jsx
@@ -27,7 +27,7 @@ export default function PluginManager() {
     try {
       parsedOverrides = JSON.parse(overridesText || '{}');
     } catch (err) {
-      setMessage('Invalid overrides JSON');
+      setMessage(`Invalid overrides JSON: ${err.message}`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- handle exceptions when parsing overrides JSON in `PluginManager`

## Testing
- `npm run build`
- `python -m py_compile $(find backend -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845b46765848332a92cc98b925ec7e0