### PR TITLE
Fix Argos package installation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,10 +26,9 @@ RUN pip install --no-cache-dir \
 # Preload common Argos Translate packages
 RUN python - <<'EOF'
 import argostranslate.package as pkg
-pkgs = [p for p in pkg.get_available_packages() if p.from_code in ("en", "es", "fr") or p.to_code in ("en", "es", "fr")]
-for p in pkgs:
-    path = pkg.download_package(p)
-    pkg.install_from_path(path)
+pkg.update_package_index()
+for package in pkg.get_available_packages():
+    package.install()
 EOF
 
 EXPOSE 8000

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -57,10 +57,9 @@ def update_argos(request: Request):
     if session != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")
     try:
-        pkgs = argos_pkg.get_available_packages()
-        for p in pkgs:
-            path = argos_pkg.download_package(p)
-            argos_pkg.install_from_path(path)
+        argos_pkg.update_package_index()
+        for p in argos_pkg.get_available_packages():
+            p.install()
         logger.info("Argos packages updated")
         return {"message": "Argos packages updated"}
     except Exception as e:


### PR DESCRIPTION
## Summary
- simplify Argos package install logic in backend Dockerfile
- update `/admin/update-argos` route to use new API

## Testing
- `docker-compose build backend` *(fails: FileNotFoundError for Docker socket)*

------
https://chatgpt.com/codex/tasks/task_e_6845d4c030688332a2b2a0b7ebdc1683