### PR TITLE
Fix missing itsdangerous package

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,8 @@ RUN pip install --no-cache-dir \
     requests \
     PyMuPDF \
     pdfkit \
-    python-dotenv
+    python-dotenv \
+    itsdangerous
 
 # Preload common Argos Translate packages
 RUN python - <<'EOF'


### PR DESCRIPTION
## Summary
- install `itsdangerous` in backend Dockerfile to satisfy auth.py dependency

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845e1cf35d48332893b822bd7363b5e