### PR TITLE
Update SECRET_KEY handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ docker-compose down
 
 ```
 
+### Environment Variables
+
+Set the `SECRET_KEY` environment variable before starting the backend. This
+key signs session cookies, and the server will fail to launch if it is not
+provided.
+
+```bash
+export SECRET_KEY=your-secret-key
+```
+
 Argos Translate models for common languages are installed automatically during
 the build. You can refresh them at any time from the **Server Settings** dialog
 by clicking <kbd>Update Argos Models</kbd>.

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -11,7 +11,9 @@ router = APIRouter()
 USERS_FILE = "./data/users.json"
 
 # Signed session serializer
-SECRET_KEY = os.environ.get("SECRET_KEY", "mnemo-secret-key")
+SECRET_KEY = os.environ.get("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable not set")
 serializer = URLSafeSerializer(SECRET_KEY, salt="mnemo-session")
 
 


### PR DESCRIPTION
## Summary
- require `SECRET_KEY` environment variable for session signing
- document the variable in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6845ec47f29883328ad7e8d1c5b5d3b8