### PR TITLE
Add configurable llm_model option

### DIFF
--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -16,6 +16,7 @@ class ConfigModel(BaseModel):
     llm_enabled: bool = False
     llm_url: str = "http://localhost:11434/api/generate"
     llm_api_key: str | None = None
+    llm_model: str = "llama3"
     zim_overrides: dict[str, dict[str, str]] = {}
 
 def load_config():
@@ -25,11 +26,13 @@ def load_config():
             "llm_enabled": False,
             "llm_url": "http://localhost:11434/api/generate",
             "llm_api_key": "",
+            "llm_model": "llama3",
             "zim_overrides": {}
         }
     with open(CONFIG_PATH) as f:
         data = json.load(f)
         data.setdefault("zim_overrides", {})
+        data.setdefault("llm_model", "llama3")
         return data
 
 def save_config(data):

--- a/backend/routes/llm.py
+++ b/backend/routes/llm.py
@@ -18,6 +18,7 @@ def llm_query(data: LLMQuery):
     if not config.get("llm_enabled"):
         return {"answer": ""}
     llm_url = config.get("llm_url", "http://localhost:11434/api/generate")
+    llm_model = config.get("llm_model", "llama3")
     api_key = config.get("llm_api_key")
     context = ""
 
@@ -27,7 +28,7 @@ def llm_query(data: LLMQuery):
             context = article.content or ""
 
     payload = {
-        "model": "llama3",  # or whatever model is loaded
+        "model": llm_model,
         "prompt": f"{context}\n\nUser question: {data.query}",
         "stream": False
     }

--- a/data/config.json
+++ b/data/config.json
@@ -3,5 +3,6 @@
   "llm_enabled": false,
   "llm_url": "http://localhost:11434/api/generate",
   "llm_api_key": "",
+  "llm_model": "llama3",
   "zim_overrides": {}
 }


### PR DESCRIPTION
## Summary
- add `llm_model` to config schema
- persist `llm_model` in `config.json`
- use the configured LLM model when querying the LLM endpoint

## Testing
- `python -m py_compile backend/routes/config.py backend/routes/llm.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ec48f5c083328c5f606858c40f82