### PR TITLE
Add Tailwind config and build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,21 @@ ZIM filenames and values may include `title` and `image` URLs:
 }
 ```
 These overrides appear on the home page grid after saving and reloading.
+
+### Frontend Development
+
+The React interface relies on TailwindCSS. Styles are processed via PostCSS during the Vite build. For local development run:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+To generate the production assets manually use:
+
+```bash
+npm run build
+```
+
+This command runs Tailwind through `postcss.config.js` so all utility classes compile correctly.

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/main.jsx
+++ b/frontend/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,13 @@
+export default {
+  content: [
+    './index.html',
+    './App.jsx',
+    './components/**/*.{js,jsx}',
+    './pages/**/*.{js,jsx}',
+    './main.jsx'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  css: {
+    postcss: './postcss.config.js',
+  },
   server: {
     port: 3000,
   },


### PR DESCRIPTION
## Summary
- create `tailwind.config.js`, `postcss.config.js` and base `index.css`
- load Tailwind styles in `main.jsx`
- configure Vite to use PostCSS
- document build steps for Tailwind in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845ec4bef188332993b619da331a216