### PR TITLE
Fix config loading

### DIFF
--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -3,7 +3,6 @@ from fastapi import APIRouter, Request, HTTPException
 from pydantic import BaseModel
 import json
 import os
-from routes.zim_loader import load_zim_files
 import argostranslate.package as argos_pkg
 from .auth import get_session_username
 from logger import logger
@@ -42,6 +41,7 @@ def get_config():
 
 @router.post("/admin/config")
 def update_config(config: ConfigModel, request: Request):
+    from routes.zim_loader import load_zim_files
     session = get_session_username(request)
     if session != "admin":
         raise HTTPException(status_code=403, detail="Admin access required")

--- a/backend/routes/zim_loader.py
+++ b/backend/routes/zim_loader.py
@@ -50,17 +50,13 @@ class ZIMReader:
 from pathlib import Path
 from threading import Lock
 from logger import logger
+from routes.config import load_config
 
 ZIM_INDEX = {}
 ZIM_META = []
 ZIM_LOCK = Lock()
-CONFIG_PATH = "./data/config.json"
 CACHE_PATH = "./cache/zim_index.json"
 FTS_DB_PATH = "./cache/search_index.db"
-
-def load_config():
-    with open(CONFIG_PATH) as f:
-        return json.load(f)
 
 def save_cache(meta):
     os.makedirs("./cache", exist_ok=True)


### PR DESCRIPTION
## Summary
- remove unused config loader from `zim_loader`
- import `load_config` from `routes.config`
- import `load_zim_files` lazily in `config` to avoid circular import

## Testing
- `python3 -m py_compile backend/routes/zim_loader.py backend/routes/config.py backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ec4a32248332a8f59bb72d21af35