### PR TITLE
Document default admin login

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ provided.
 export SECRET_KEY=your-secret-key
 ```
 
+### Default Admin Login
+
+An initial administrator account is preconfigured in `data/users.json`:
+
+- **Username**: `admin`
+- **Password**: `admin123`
+
+Edit this file and restart the backend if you need to change the credentials.
+
 Argos Translate models for common languages are installed automatically during
 the build. You can refresh them at any time from the **Server Settings** dialog
 by clicking <kbd>Update Argos Models</kbd>.


### PR DESCRIPTION
## Summary
- document default admin login credentials in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684724b8c4848332b84904aa1b904645