### PR TITLE
Fix circular import on app startup

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -6,7 +6,6 @@ import bcrypt
 from itsdangerous import URLSafeSerializer, BadSignature
 import time
 from logger import logger
-from routes.config import load_config
 
 router = APIRouter()
 
@@ -57,6 +56,7 @@ class AddUserRequest(BaseModel):
 
 @router.post("/auth/login")
 def login(data: LoginRequest, response: Response):
+    from routes.config import load_config
     if not os.path.exists(USERS_FILE):
         raise HTTPException(status_code=401, detail="No users defined")
 


### PR DESCRIPTION
## Summary
- fix circular import between `auth` and `config`

## Testing
- `python -m py_compile backend/routes/auth.py backend/routes/config.py`


------
https://chatgpt.com/codex/tasks/task_e_68480e08f7748332b0ecbf8025fff857