### PR TITLE
Improve host IP detection for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ specified, the default is 30 minutes.
 
 #### Building the Frontend
 
-Running `npm run build` will now prompt you for the backend host IP address. The
-script lists detected local IPs and sets `VITE_BACKEND_URL` accordingly before
-invoking the Vite build. You can skip the prompt by setting the `HOST_IP`
-environment variable or by calling `npm run build:actual` directly.
+Running `npm run build` attempts to detect the host IP automatically using the
+`host.docker.internal` DNS entry. If detection fails and a TTY is available, the
+script prompts for the backend IP. You can also set the `HOST_IP` environment
+variable or call `npm run build:actual` directly to skip detection.
 
 The provided URL becomes the API endpoint that the browser communicates with.
 
@@ -137,6 +137,6 @@ To generate the production assets manually use:
 npm run build
 ```
 
-You will be asked for the backend IP address unless the `HOST_IP` environment
-variable is already set. The command runs Tailwind through `postcss.config.js`
-so all utility classes compile correctly.
+If automatic detection fails, the script falls back to an interactive prompt
+unless `HOST_IP` is already defined. The command runs Tailwind through
+`postcss.config.js` so all utility classes compile correctly.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,9 +4,9 @@ FROM node:20 AS builder
 WORKDIR /app
 COPY . .
 
-ARG VITE_BACKEND_URL=http://backend:8000
-ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
-RUN npm install && npm run build:actual
+ARG HOST_IP=""
+ENV HOST_IP=$HOST_IP
+RUN npm install && npm run build
 
 # Stage 2: Serve with NGINX
 FROM nginx:alpine

--- a/frontend/scripts/build.js
+++ b/frontend/scripts/build.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const os = require('os');
+const dns = require('dns');
 const readline = require('readline');
 const { spawn } = require('child_process');
 
@@ -21,9 +22,19 @@ const rl = readline.createInterface({ input: process.stdin, output: process.stdo
 
 const ask = (q) => new Promise(res => rl.question(q, res));
 
+const lookupHostIp = () => new Promise(resolve => {
+  dns.lookup('host.docker.internal', (err, address) => {
+    if (!err && address) resolve(address);
+    else resolve(null);
+  });
+});
+
 (async () => {
   let ip = process.env.HOST_IP;
   if (!ip) {
+    ip = await lookupHostIp();
+  }
+  if (!ip && process.stdin.isTTY) {
     ip = (await ask('Enter backend host IP (default 127.0.0.1): ')).trim();
   }
   rl.close();


### PR DESCRIPTION
## Summary
- auto-detect host IP during frontend build
- update Dockerfile to use the build script
- document new host IP detection behavior

## Testing
- `npm install`
- `npm run build` *(fails: prompts for backend host IP when detection fails)*
- `HOST_IP=127.0.0.1 npm run build`
- `npm test` *(fails: missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684bbbae74bc8332a5c16b923ca1c895