### PR TITLE
Improve ZIM loading with async indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ git clone https://github.com/AntGod6123/Mnemo.git
 cd Mnemo
 sudo docker compose up --build
 
-``` 
+```
 
 This command builds the backend and frontend containers. After they start,
 visit <http://localhost:3000> to use the interface. The FastAPI backend is
-available at <http://localhost:8000>. If you want LLM features, run your own
+available at <http://localhost:8000>. Search indexes start rebuilding in the
+background so the UI loads immediately. If you want LLM features, run your own
 service separately (for example an Ollama container) and configure its URL in
 the admin panel. When you're done, stop the stack with <kbd>Ctrl</kbd>+<kbd>C</kbd>
 and clean up the containers using:
@@ -95,7 +96,9 @@ Translation support is optional. Install the Argos Translate models from the
 
 Place your ZIM archives in `./data/zim` on the host. This folder is mounted into
 the backend container at `/app/data/zim`. Any `.zim` files you drop there will
-be loaded automatically when the stack starts.
+be loaded automatically when the stack starts. Search indexes are rebuilt in the
+background so the server becomes available immediately; indexing is skipped if a
+matching index already exists.
 
 Place additional ZIM archives in the configured `ZIM_DIR` folder and restart the backend to load them.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,6 @@ app.include_router(llm_router)
 app.include_router(auth_router)
 app.include_router(logs_router)
 
-# Load ZIMs on startup
+# Load ZIMs on startup without blocking on indexing
 logger.info("Mnemo server starting up")
-load_zim_files()
+load_zim_files(blocking=False)


### PR DESCRIPTION
## Summary
- rebuild search indexes in background threads
- avoid rebuilding existing indexes by tracking file info in cache
- call `load_zim_files` in non-blocking mode on startup
- document asynchronous indexing behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e951639e8833299a07bedc4695607