### PR TITLE
Fix ZIM indexing and open collections

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -23,13 +23,14 @@ export default function App() {
 
   return (
     <div className="p-4">
-      {page === 'home' && <Home onSearch={handleSearch} />}
+      {page === 'home' && <Home onSearch={handleSearch} onOpenZim={openTab} />}
       {page === 'results' && (
         <SearchResults
           initialQuery={searchData.query}
           initialResults={searchData.results}
           initialAnswer={searchData.answer}
           onHome={goHome}
+          onOpenArticle={openTab}
         />
       )}
       <ZimBrowserTabs ref={tabsRef} />

--- a/frontend/pages/Home.jsx
+++ b/frontend/pages/Home.jsx
@@ -4,7 +4,7 @@ import Header from '../components/Header';
 import { apiFetch } from '../api';
 import logo from '../logo.png';
 
-export default function Home({ onSearch }) {
+export default function Home({ onSearch, onOpenZim }) {
   const [zimFiles, setZimFiles] = useState([]);
 
   const loadZims = () => {
@@ -31,9 +31,12 @@ export default function Home({ onSearch }) {
           {zimFiles.map((zim, i) => (
             <a
               key={i}
-              href={`#/zim/${zim.file}`}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={zim.main_page ? '#' : `#/zim/${zim.file}`}
+              onClick={e => {
+                if (!zim.main_page) return;
+                e.preventDefault();
+                if (onOpenZim) onOpenZim(zim.file, zim.main_page, zim.title);
+              }}
               className="block p-4 rounded-xl bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition text-left shadow-sm"
             >
               {zim.image ? (

--- a/frontend/pages/SearchResults.jsx
+++ b/frontend/pages/SearchResults.jsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import SearchPanel from '../components/SearchPanel';
-import { API_BASE } from '../api';
 import Header from '../components/Header';
 
-export default function SearchResults({ initialQuery, initialResults, initialAnswer, onHome }) {
+export default function SearchResults({ initialQuery, initialResults, initialAnswer, onHome, onOpenArticle }) {
   const [query, setQuery] = useState(initialQuery || '');
   const [results, setResults] = useState(initialResults || []);
   const [answer, setAnswer] = useState(initialAnswer || '');
@@ -30,9 +29,11 @@ export default function SearchResults({ initialQuery, initialResults, initialAns
         {results.map((r, i) => (
           <li key={i} className="mb-2">
             <a
-              href={`${API_BASE}/article/${r.zim_id}/${r.path}`}
-              target="_blank"
-              rel="noopener noreferrer"
+              href="#"
+              onClick={e => {
+                e.preventDefault();
+                if (onOpenArticle) onOpenArticle(r.zim_id, r.path, r.title);
+              }}
               className="text-blue-600 dark:text-blue-300 hover:underline"
             >
               {r.title}


### PR DESCRIPTION
## Summary
- ensure only HTML articles are indexed from ZIM files
- expose ZIM main page and use it when opening a collection
- open search results and collection links inside Mnemo tabs

## Testing
- `npm test --silent`
- `pytest -q`
- `ruff check backend frontend` *(fails: unrecognized subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_684eadfd61988332bfa57395a84ccced